### PR TITLE
glog: update rate limit config

### DIFF
--- a/glog.go
+++ b/glog.go
@@ -430,9 +430,10 @@ type loggingT struct {
 	traceLocation traceLocation
 	// These flags are modified only under lock, although verbosity may be fetched
 	// safely using atomic.LoadInt32.
-	vmodule     moduleSpec    // The state of the -vmodule flag.
-	verbosity   Level         // V logging level, the value of the -v flag/
-	rateLimiter *rate.Limiter // Rate limiter
+	vmodule           moduleSpec    // The state of the -vmodule flag.
+	verbosity         Level         // V logging level, the value of the -v flag/
+	rateLimiter       *rate.Limiter // Rate limiter
+	rateLimitDuration time.Duration
 	// onFatalFunc allows to handle data on Fatal log
 	onFatalFunc func([]byte)
 }

--- a/glog_config_test.go
+++ b/glog_config_test.go
@@ -20,6 +20,9 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+	"time"
+
+	"golang.org/x/time/rate"
 )
 
 func TestGetSetVGlobal(t *testing.T) {
@@ -82,6 +85,21 @@ func TestGetSetVModule(t *testing.T) {
 		t.Fatalf("unexpected previous vmodule: %#v", prev)
 	}
 
+}
+
+func TestLimitToDuration(t *testing.T) {
+	m := map[rate.Limit]time.Duration{
+		rate.Every(time.Second):      time.Second,
+		rate.Every(0):                0,
+		rate.Every(time.Hour):        time.Hour,
+		rate.Every(time.Millisecond): time.Millisecond,
+	}
+	for l, d := range m {
+		newD := limitToDuration(l)
+		if d != newD {
+			t.Errorf("limitToDuration(%v) = %d, should be %v", l, newD, d)
+		}
+	}
 }
 
 func TestSetOutput(t *testing.T) {


### PR DESCRIPTION
This is similar to my previous change.

* A nil pointer dereference was fixed in GetRateLimit.
* SetRateLimit now returns the previously set rate limit.

Adding return values to SetRateLimit signature is mostly safe. In Go, you can't use a void value as an actual value.