### PR TITLE
glog: Add flag to discard all logs

### DIFF
--- a/glog.go
+++ b/glog.go
@@ -399,6 +399,8 @@ type loggingT struct {
 	toWriter     bool // The -logtostderr flag.
 	alsoToStderr bool // The -alsologtostderr flag.
 
+	discard *bool // The -discard flag
+
 	// writer is the writer for log output.
 	writer io.Writer
 
@@ -696,6 +698,8 @@ func (l *loggingT) output(s severity, buf *buffer, file string, line int, alsoTo
 	if !flag.Parsed() {
 		l.writer.Write([]byte("ERROR: logging before flag.Parse: "))
 		l.writer.Write(data)
+	} else if *l.discard {
+		// Do nothing
 	} else if l.toWriter {
 		l.writer.Write(data)
 	} else {

--- a/glog_config.go
+++ b/glog_config.go
@@ -34,7 +34,7 @@ func init() {
 		"comma-separated list of pattern=N settings for file-filtered logging")
 	flag.Var(&logging.traceLocation, "log_backtrace_at",
 		"when logging hits line file:N, emit a stack trace")
-	logging.discard = flag.Bool("discard", false, "discard all logs")
+	logging.discard = flag.Bool("glog_discard", false, "discard all logs")
 
 	logging.toWriter = true
 	logging.writer = os.Stderr

--- a/glog_config.go
+++ b/glog_config.go
@@ -34,6 +34,7 @@ func init() {
 		"comma-separated list of pattern=N settings for file-filtered logging")
 	flag.Var(&logging.traceLocation, "log_backtrace_at",
 		"when logging hits line file:N, emit a stack trace")
+	logging.discard = flag.Bool("discard", false, "discard all logs")
 
 	logging.toWriter = true
 	logging.writer = os.Stderr

--- a/glog_test.go
+++ b/glog_test.go
@@ -536,3 +536,23 @@ func BenchmarkInfoRateLimited(b *testing.B) {
 		Info("rate")
 	}
 }
+
+func TestDiscard(t *testing.T) {
+	setFlags()
+	*logging.discard = true
+	defer func() {
+		*logging.discard = false
+	}()
+	defer logging.swap(logging.newBuffers())
+
+	log := "log to buffer"
+	Info(log)
+	if contains(infoLog, log, t) {
+		t.Errorf("Unexpected log written: %s", contents(infoLog))
+	}
+
+	Error(log)
+	if contains(errorLog, log, t) {
+		t.Errorf("Unexpected log written: %s", contents(errorLog))
+	}
+}


### PR DESCRIPTION
The main use case is discarding logs during a benchmark. The interwoven logs interfere with the benchmark output.